### PR TITLE
GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,18 @@
+---
+name: Bug Report
+about: Report a problem or unexpected behavior
+title: "[Bug] "
+labels: bug
+---
+
+**What's the problem?**
+
+<!-- Describe the bug clearly and concisely. -->
+
+**Expected behavior:**
+
+<!-- What did you expect to happen? -->
+
+**Additional context:**
+
+<!-- Add logs, screenshots, or any other helpful context. -->

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,18 @@
+---
+name: Feature Request
+about: Suggest a new feature or improvement
+title: "[Feature] "
+labels: enhancement
+---
+
+**Describe the feature**
+
+<!-- What is the feature or improvement you’re suggesting? -->
+
+**What's the purpose?**
+
+<!-- Why should this be added? What problem does it solve or benefit does it bring? -->
+
+**How do you think it should be implemented?**
+
+<!-- Share your idea for how it could work or be integrated. -->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,18 @@
+---
+name: Question
+about: Ask a question or get clarification about the project
+title: "[Question] "
+labels: question
+---
+
+**What’s your question?**
+
+<!-- Clearly state your question. Be specific. -->
+
+**What have you tried so far?**
+
+<!-- Mention any research, tests, or attempts you’ve already made. -->
+
+**Anything else?**
+
+<!-- Add context, code snippets, or screenshots if needed. -->


### PR DESCRIPTION
This PR adds basic GitHub issue templates for reporting bugs, requesting features, and asking questions. Each template is designed to guide contributors to provide clear and structured information.

Feel free to modify if you wish.